### PR TITLE
FOLIO-722 initial repo setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ui-notes
 
-Copyright (C) 2018 The Open Library Foundation
+Copyright (C) 2019 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License, Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 

--- a/README.md
+++ b/README.md
@@ -45,3 +45,13 @@ Now that your new app is running, search the code for "`stripes-new-app`" to fin
 Read the [Stripes Module Developer's Guide](https://github.com/folio-org/stripes/blob/master/doc/dev-guide.md).
 
 Update this README with information about your app.
+
+## Additional information
+
+Other [modules](https://dev.folio.org/source-code/#client-side).
+
+See project [UINOTES](https://issues.folio.org/browse/UINOTES)
+at the [FOLIO issue tracker](https://dev.folio.org/guidelines/issue-tracker).
+
+Other FOLIO Developer documentation is at [dev.folio.org](https://dev.folio.org/)
+


### PR DESCRIPTION
Updated README to use current initial year of creation FOLIO-360. (Also updated the template in stripes-cli repo.)

Added the link to this project's issue tracker.

The rest of the initial setup seems fine. Thanks.