### PR TITLE
UINOTES-22 - Create a permission: Settings : Configure notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
         "permissionName": "settings.notes.enabled",
         "displayName": "Settings (notes): display list of settings pages",
         "subPermissions": [
-          "settings.enabled"
+          "settings.enabled",
+          "note.types.allops"
         ],
         "visible": true
       }


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UINOTES-22 we need to create a permission that enables/disables the display of Notes in the Settings panel, allowing a user to configure note types.

## Approach
- Looked into current permissions in ui-notes by examining package.json
- Found we already had definitions for `settings.notes.enabled` and `module.notes.enabled`
- Verified access is handled properly by testing against https://folio-testing.aws.indexdata.com/settings/notes/general
- Added subpermission `note.types.allops` from mod-notes access to handle back end permission to CRUD note types.
https://github.com/folio-org/mod-notes/blob/master/descriptors/ModuleDescriptor-template.json#L187

#### TODOS and Open Questions
- [ ] Do not believe unit test is required here since control of settings/notes is done within stripes settings component and is outside the scope of this module.
https://github.com/folio-org/stripes-core/blob/8c0f0d0dde004b4f5691104d829d5fa2f6749072/src/components/Settings/Settings.js#L48

## Learning
- https://github.com/folio-org/stripes-core/blob/master/doc/permissions.md#access-to-settings
- https://github.com/folio-org/stripes/blob/master/doc/dev-guide.md#testing-for-permission


## Screenshots
Test of permission in folio-testing environment
![2019-05-20 11 49 14](https://user-images.githubusercontent.com/19415226/58035522-f6a40a80-7af6-11e9-9609-8b440b130700.gif)

