### PR TITLE
Define UI permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,5 +3,6 @@
 ## [1.0.0](https://github.com/folio-org/ui-notes/tree/v1.0.0) (2019-05-08)
 
 * New app created 
-* Added project configs for linting, Jeckin, browser, git and etc.
+* Added project configs for linting, Jenkins, browser, git and etc.
 * Added note types settings (UINOTES-11).
+* Defined UI permissions

--- a/package.json
+++ b/package.json
@@ -72,6 +72,55 @@
           "note.types.allops"
         ],
         "visible": true
+      },
+      {
+        "permissionName": "ui-notes.item.view",
+        "displayName": "Notes - get individual note from storage",
+        "subPermissions": [
+          "notes.item.get",
+          "notes.domain.all",
+          "module.notes.enabled"
+        ],
+        "visible": true
+      },
+      {
+        "permissionName": "ui-notes.item.create",
+        "displayName": "Notes - create note",
+        "subPermissions": [
+          "notes.item.post",
+          "notes.domain.all",
+          "ui-notes.item.view"
+        ],
+        "visible": true
+      },
+      {
+        "permissionName": "ui-notes.item.edit",
+        "displayName": "Notes - modify note",
+        "subPermissions": [
+          "notes.item.put",
+          "notes.domain.all",
+          "ui-notes.item.view"
+        ],
+        "visible": true
+      },
+      {
+        "permissionName": "ui-notes.item.delete",
+        "displayName": "Notes - delete note",
+        "subPermissions": [
+          "notes.item.delete",
+          "notes.domain.all",
+          "ui-notes.item.view"
+        ],
+        "visible": true
+      },
+      {
+        "permissionName": "ui-notes.item.assign-unassign",
+        "displayName": "Note links - update note links",
+        "subPermissions": [
+          "note.links.collection.put",
+          "ui-notes.item.view"
+        ],
+        "visible": true
       }
     ]
   }


### PR DESCRIPTION
In this PR, I defined UI permissions described in the following stories:
[UINOTES-23](https://issues.folio.org/browse/UINOTES-23), [UINOTES-24](https://issues.folio.org/browse/UINOTES-24), [UINOTES-25](https://issues.folio.org/browse/UINOTES-25), [UINOTES-26](https://issues.folio.org/browse/UINOTES-26), [UINOTES-27](https://issues.folio.org/browse/UINOTES-27)
### Defined permissions:
* Notes - get individual note from storage
* Notes - create note
* Notes - modify note
* Notes - delete note
* Note links - update note links