### PR TITLE
STSMACOM-223: fix notes permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
         "displayName": "Notes - get individual note from storage",
         "subPermissions": [
           "notes.item.get",
+          "notes.collection.get",
+          "notes.collection.get.by.status",
           "notes.domain.all",
           "module.notes.enabled"
         ],


### PR DESCRIPTION
I added 2 missing back-end permissions responsible for GETting collection of notes