### PR TITLE
UINOTES-57: add GET note types permission as a note view subpermission

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "permissionName": "ui-notes.item.view",
         "displayName": "Notes: Can view a note",
         "subPermissions": [
+          "note.types.collection.get",
           "notes.item.get",
           "notes.collection.get",
           "notes.collection.get.by.status",


### PR DESCRIPTION
The permission "Notes: Can view a note" requires the permission to GET a collection of note types. Currently, it's missing. However, we didn't face any bugs because while using and testing notes functionality, we always gave a user the permission to see the notes settings, which includes all of the existing permission related to note types.

**UPDATE**:
Actually, there is a bug related to the note types permissions in the backlog. This PR fixes it.
https://issues.folio.org/browse/UINOTES-57