### PR TITLE
UINOTES-79: Notes app: Move permission names to translation file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.0.0] (IN PROGRESS)
 
 * Update react-intl to v4
+* Added permission display names to translations (UINOTES-79).
 
 ## [2.0.0](https://github.com/folio-org/ui-notes/tree/v2.0.0) (2020-03-13)
 [Full Changelog](https://github.com/folio-org/ui-notes/compare/v1.4.0...v2.0.0)

--- a/translations/ui-notes/en.json
+++ b/translations/ui-notes/en.json
@@ -6,5 +6,13 @@
   "settings.noteType": "Note type",
   "settings.notes": "Notes",
   "settings.duplicated": "{field} duplicated",
-  "settings.maxAmout": "Maximum # of note types allowed is {amount}."
-  }
+  "settings.maxAmout": "Maximum # of note types allowed is {amount}.",
+
+  "permission.module.notes.enabled": "UI: ui-notes module is enabled",
+  "permission.notes.enabled": "Settings (notes): display list of settings pages",
+  "permission.item.view": "Notes: Can view a note",
+  "permission.item.create": "Notes: Can create a note",
+  "permission.item.edit": "Notes: Can edit a note",
+  "permission.item.delete": "Notes: Can delete a note",
+  "permission.item.assign-unassign": "Notes: Can assign and unassign a note"
+}


### PR DESCRIPTION
## Purpose
- Add permission display names to translation file to be picked up by `react-intl`