### PR TITLE
Increased "notes" interface version to "2.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-notes
 
+## [5.0.0] (IN PROGRESS)
+
+* Increment `notes` interface to `2.0`
+
 ## [4.0.0] (https://github.com/folio-org/ui-notes/tree/v4.0.0) (2020-10-14)
 [Full Changelog](https://github.com/folio-org/ui-notes/compare/v3.0.0...v4.0.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/notes",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Note types manager",
   "repository": "",
   "main": "src/index.js",
@@ -58,7 +58,7 @@
     "displayName": "ui-notes.meta.title",
     "route": "/notes",
     "okapiInterfaces": {
-      "notes": "1.0"
+      "notes": "2.0"
     },
     "queryResource": "query",
     "permissionSets": [


### PR DESCRIPTION
## Description
- Increased `notes` interface version to `2.0`.

## Related PRs
https://github.com/folio-org/stripes-smart-components/pull/967
https://github.com/folio-org/ui-users/pull/1587