### PR TITLE
UINOTES-98: Hide module.notes.enabled permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [5.0.0] (IN PROGRESS)
 
 * Increment `notes` interface to `2.0`
+* Hide 'module.notes.enabled' permission (UINOTES-98).
 
 ## [4.0.0] (https://github.com/folio-org/ui-notes/tree/v4.0.0) (2020-10-14)
 [Full Changelog](https://github.com/folio-org/ui-notes/compare/v3.0.0...v4.0.0)

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
       {
         "permissionName": "module.notes.enabled",
         "displayName": "UI: ui-notes module is enabled",
-        "visible": true
+        "visible": false
       },
       {
         "permissionName": "settings.notes.enabled",


### PR DESCRIPTION
## Description
Hide `module.notes.enabled` permission so users can't assign it

## Issues
[UINOTES-98](https://issues.folio.org/browse/UINOTES-98)
