### PR TITLE
UINOTES-115: Settings > Notes > Note types : Cannot add or edit a note type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change history for ui-notes
 
+## [6.0.1] (IN PROGRESS)
+
+* Settings > Notes > Note types : Cannot add or edit a note type. (UINOTES-115)
+
 ## [6.0.0] (https://github.com/folio-org/ui-notes/tree/v6.0.0) (2020-10-01)
+
 * Compile Translation Files into AST Format (UINOTES-105).
 * Update stripes v7 and react v17. (UINOTES-110).
 

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
         "displayName": "Notes: Can view a note",
         "subPermissions": [
           "note.types.collection.get",
+          "note.types.item.get",
           "notes.item.get",
           "notes.collection.get",
           "notes.collection.get.by.status",
@@ -102,6 +103,7 @@
         "displayName": "Notes: Can create a note",
         "subPermissions": [
           "notes.item.post",
+          "note.types.item.post",
           "notes.domain.all",
           "ui-notes.item.view"
         ],
@@ -112,6 +114,7 @@
         "displayName": "Notes: Can edit a note",
         "subPermissions": [
           "notes.item.put",
+          "note.types.item.put",
           "notes.domain.all",
           "ui-notes.item.view"
         ],
@@ -122,6 +125,7 @@
         "displayName": "Notes: Can delete a note",
         "subPermissions": [
           "notes.item.delete",
+          "note.types.item.delete",
           "notes.domain.all",
           "ui-notes.item.view"
         ],


### PR DESCRIPTION
## Description
Added missing permissions to notes endpoints

## Issues
[UINOTES-115](https://issues.folio.org/browse/UINOTES-115)