### PR TITLE
UINOTES-112: Refactor '.all' permissions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [6.0.0] (https://github.com/folio-org/ui-notes/tree/v6.0.0) (2020-10-01)
 * Compile Translation Files into AST Format (UINOTES-105).
 * Update stripes v7 and react v17. (UINOTES-110).
+* Refactor '.all' permissions. (UINOTES-112)
 
 ## [5.0.0] (https://github.com/folio-org/ui-notes/tree/v5.0.0) (2020-03-04)
 [Full Changelog](https://github.com/folio-org/ui-notes/compare/v4.0.0...v5.0.0)

--- a/package.json
+++ b/package.json
@@ -80,7 +80,11 @@
         "displayName": "Settings (Notes): Edit and View General settings",
         "subPermissions": [
           "settings.enabled",
-          "note.types.allops"
+          "note.types.item.get",
+          "note.types.collection.get",
+          "note.types.item.post",
+          "note.types.item.put",
+          "note.types.item.delete"
         ],
         "visible": true
       },


### PR DESCRIPTION
# UINOTES-112 refactor psets away from backend ".all" permissions

## Purpose
Refactor '.all' permissions

Issue: [UINOTES-112](https://issues.folio.org/browse/UINOTES-112)
