### PR TITLE
UINOTES-132: Settings > Notes > General > Note types - Remove # of notes column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * ui-notes: Configure GitHub actions. (UINOTES-120)
 * Replace `babel-eslint` with `@babel/eslint-parser`. (UINOTES-125)
 * update NodeJS to v16 in GitHub Actions. (UINOTES-126)
+* Settings > Notes > General > Note types - Remove # of notes column. (UINOTES-132)
 
 ## [6.1.0] (https://github.com/folio-org/ui-notes/tree/v6.1.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-notes/compare/v6.0.1...v6.1.0)

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "displayName": "ui-notes.meta.title",
     "route": "/notes",
     "okapiInterfaces": {
-      "notes": "2.0"
+      "notes": "3.0"
     },
     "queryResource": "query",
     "permissionSets": [

--- a/src/settings/note-types-settings.js
+++ b/src/settings/note-types-settings.js
@@ -25,7 +25,8 @@ const NoteTypesSettings = ({ stripes }) => {
     return validate(item, index, items, 'name', label);
   };
 
-  const suppressDelete = noteType => get(noteType, 'usage.noteTotal') > 0;
+  const suppressDelete = noteType => get(noteType, 'usage.isAssigned');
+
   const suppressEdit = () => false;
 
   return (
@@ -38,8 +39,7 @@ const NoteTypesSettings = ({ stripes }) => {
       labelSingular={label}
       objectLabel={<FormattedMessage id="ui-notes.settings.notes" />}
       visibleFields={['name']}
-      hiddenFields={['lastUpdated']}
-      formatter={{ 'numberOfObjects': (item) => get(item, 'usage.noteTotal') }}
+      hiddenFields={['lastUpdated', 'numberOfObjects']}
       actionSuppressor={{
         edit: suppressEdit,
         delete: suppressDelete

--- a/src/settings/note-types-settings.test.js
+++ b/src/settings/note-types-settings.test.js
@@ -32,4 +32,30 @@ describe('Given NoteTypesSettings', () => {
 
     expect(getByText('ui-notes.settings.noteTypes')).toBeDefined();
   });
+
+  it('should render ConnectedControlledVocab component with correct props', () => {
+    const expectedProps = {
+      stripes,
+      baseUrl: 'note-types',
+      records: 'noteTypes',
+      label: 'ui-notes.settings.noteTypes',
+      labelSingular: 'ui-notes.settings.noteType',
+      visibleFields: ['name'],
+      hiddenFields: ['lastUpdated', 'numberOfObjects'],
+      nameKey: 'name',
+      id: 'noteTypes',
+      sortby: 'name',
+    };
+
+    renderNoteTypesSettings({ stripes });
+    expect(ControlledVocab).toHaveBeenNthCalledWith(1, expect.objectContaining(expectedProps), {});
+  });
+
+  it('should have correct suppressDelete function', () => {
+    const noteType = {
+      usage: { isAssigned: true },
+    };
+    renderNoteTypesSettings({ stripes });
+    expect(ControlledVocab.mock.calls[0][0].actionSuppressor.delete(noteType)).toBeTruthy();
+  });
 });


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
- Remove # of notes column
- Make sure that the delete icon only displays when no note type is assigned to a note
- Make sure General remains the default note type
- Upgrade "notes" interface version to 3.0
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
![image](https://user-images.githubusercontent.com/77053927/178982704-03ce9619-7a34-438d-84cf-21d8efb9990c.png)

<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
