### PR TITLE
UINOTES-137 'ui-notes.settings.noteType' value is displayed as column title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Settings > Notes > General > Note types - Remove # of notes column. (UINOTES-132)
 * NOTES - provide local translations to ControlledVocab. (UINOTES-135)
+* "ui-notes.settings.noteType" value is displayed as column title. (UINOTES-137)
 
 ## [6.2.0] (https://github.com/folio-org/ui-notes/tree/v6.2.0) (2022-06-20)
 [Full Changelog](https://github.com/folio-org/ui-notes/compare/v6.1.0...v6.2.0)

--- a/translations/ui-notes/en.json
+++ b/translations/ui-notes/en.json
@@ -2,6 +2,7 @@
   "meta.title": "Notes",  
   "settings.general": "General",
   "settings.index.paneTitle": "Notes",
+  "settings.noteType": "Note type",
   "settings.noteTypes": "Note types",
   "settings.noteTypes.deleteEntry": "Delete note type",
   "settings.noteTypes.termDeleted": "The note type <b>{term}</b> was successfully <b>deleted</b>",


### PR DESCRIPTION
## Description
Added missing `ui-notes.settings.noteType` translation

## Issues
[UINOTES-137](https://issues.folio.org/browse/UINOTES-137)