### PR TITLE
UINOTES-139 bump stripes to 8.0.0 for Orchid/2023-R1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-notes
 
+## [8.0.0] (https://github.com/folio-org/ui-notes/tree/v8.0.0) (IN PROGRESS)
+
+* bump stripes to 8.0.0 for Orchid/2023-R1. (UINOTES-139)
+
 ## [7.0.0] (https://github.com/folio-org/ui-notes/tree/v7.0.0) (2022-10-24)
 [Full Changelog](https://github.com/folio-org/ui-notes/compare/v6.2.0...v7.0.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/notes",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "Note types manager",
   "repository": "",
   "main": "src/index.js",
@@ -26,7 +26,7 @@
     "@babel/plugin-transform-runtime": "^7.10.5",
     "@babel/preset-react": "^7.10.4",
     "@folio/eslint-config-stripes": "^6.1.0",
-    "@folio/stripes": "^7.0.0",
+    "@folio/stripes": "^8.0.0",
     "@folio/stripes-cli": "^2.4.0",
     "@formatjs/cli": "^4.2.7",
     "@testing-library/jest-dom": "^5.11.1",
@@ -54,7 +54,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^7.0.0",
+    "@folio/stripes": "^8.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router": "^5.2.0",


### PR DESCRIPTION
## Description
bump stripes to 8.0.0 for Orchid/2023-R1

## Issues
[UINOTES-139](https://issues.folio.org/browse/UINOTES-139)