### PR TITLE
UINOTES-147 Update Node.js to v18 in GitHub Actions

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -27,7 +27,7 @@ jobs:
       FOLIO_NPM_REGISTRY: 'https://repository.folio.org/repository/npm-folio/'
       FOLIO_NPM_REGISTRY_AUTH: '//repository.folio.org/repository/npm-folio/'
       FOLIO_MD_REGISTRY: 'https://folio-registry.dev.folio.org'
-      NODEJS_VERSION: '16'
+      NODEJS_VERSION: '18'
       JEST_JUNIT_OUTPUT_DIR: 'artifacts/jest-junit'
       JEST_COVERAGE_REPORT_DIR: 'artifacts/coverage-jest/lcov-report/'
       OKAPI_PULL: '{ "urls" : [ "https://folio-registry.dev.folio.org" ] }'

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -24,7 +24,7 @@ jobs:
       FOLIO_NPM_REGISTRY: 'https://repository.folio.org/repository/npm-folioci/'
       FOLIO_NPM_REGISTRY_AUTH: '//repository.folio.org/repository/npm-folioci/'
       FOLIO_MD_REGISTRY: 'https://folio-registry.dev.folio.org'
-      NODEJS_VERSION: '16'
+      NODEJS_VERSION: '18'
       JEST_JUNIT_OUTPUT_DIR: 'artifacts/jest-junit'
       JEST_COVERAGE_REPORT_DIR: 'artifacts/coverage-jest/lcov-report/'
       SQ_LCOV_REPORT: 'artifacts/coverage-jest/lcov.info'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [9.0.0] (https://github.com/folio-org/ui-notes/tree/v9.0.0) (IN PROGRESS)
 
 * Added a permission `Settings (Notes): View General settings`. (UINOTES-141)
+* Update Node.js to v18 in GitHub Actions. (UINOTES-147)
 
 ## [8.0.0] (https://github.com/folio-org/ui-notes/tree/v8.0.0) (2023-02-14)
 [Full Changelog](https://github.com/folio-org/ui-notes/compare/v7.0.0...v8.0.0)

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "repository": "",
   "main": "src/index.js",
   "license": "Apache-2.0",
-  "engines": {
-    "node": ">=14.0.0"
-  },
   "scripts": {
     "start": "stripes serve",
     "build": "stripes build --output ./dist",


### PR DESCRIPTION
## Description
Update Node.js to v18 in GitHub Actions

## Issues
[UINOTES-147](https://issues.folio.org/browse/UINOTES-147)