### PR TITLE
UINOTES-173 provide a custom error message getter to ControlledVocab (follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Change history for ui-notes
 
-## [11.1.0] (IN PROGRESS)
+## [12.0.0] (IN PROGRESS)
 
 * Settings > Notes> Add Notes application icon. (UINOTES-169)
-* Handle BE error when a note type limit has been reached. (UINOTES-169)
+* *BREAKING* Handle BE error when a note type limit has been reached. (UINOTES-173)
 
 ## [11.0.0] (https://github.com/folio-org/ui-notes/tree/v11.0.0) (2025-03-13)
 [Full Changelog](https://github.com/folio-org/ui-notes/compare/v10.0.0...v11.0.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/notes",
-  "version": "11.0.0",
+  "version": "12.0.0",
   "description": "Note types manager",
   "repository": "",
   "main": "src/index.js",
@@ -20,7 +20,7 @@
     "@babel/eslint-parser": "^7.17.0",
     "@folio/eslint-config-stripes": "^8.0.0",
     "@folio/jest-config-stripes": "^3.0.0",
-    "@folio/stripes": "^10.0.0",
+    "@folio/stripes": "^10.1.0",
     "@folio/stripes-cli": "^4.0.0",
     "eslint": "^7.32.0",
     "eslint-plugin-jest": "^24.1.3",
@@ -40,7 +40,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^10.0.0",
+    "@folio/stripes": "^10.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-intl": "^7.1.5",

--- a/src/settings/note-types-settings.js
+++ b/src/settings/note-types-settings.js
@@ -6,10 +6,7 @@ import {
 } from 'react-intl';
 import { get } from 'lodash';
 
-import {
-  TitleManager,
-  useCallout,
-} from '@folio/stripes/core';
+import { TitleManager } from '@folio/stripes/core';
 import { ControlledVocab } from '@folio/stripes/smart-components';
 
 import {
@@ -26,7 +23,6 @@ const propTypes = {
 
 const NoteTypesSettings = ({ stripes }) => {
   const { formatMessage } = useIntl();
-  const callout = useCallout();
   const ConnectedControlledVocab = stripes.connect(ControlledVocab);
 
   const paneTitle = formatMessage({ id: 'ui-notes.settings.noteTypes' });

--- a/src/settings/note-types-settings.js
+++ b/src/settings/note-types-settings.js
@@ -13,7 +13,7 @@ import {
 import { ControlledVocab } from '@folio/stripes/smart-components';
 
 import {
-  handleCreateFail,
+  getErrorMessage,
   validate,
 } from '../util';
 
@@ -67,7 +67,7 @@ const NoteTypesSettings = ({ stripes }) => {
           name: label
         }}
         canCreate={canEdit}
-        onCreateFail={(res) => handleCreateFail(res, callout.sendCallout)}
+        getCustomErrorMessages={getErrorMessage}
         nameKey="name"
         id="noteTypes"
         sortby="name"

--- a/src/util.js
+++ b/src/util.js
@@ -28,20 +28,26 @@ export function validate(item, index, items, field, label) {
 
 export const NOTE_TYPES_LIMIT_REACHED_ERROR = 'NOTE_TYPES_LIMIT_REACHED';
 
-export const handleCreateFail = (res, sendCallout) => {
-  res.json().then(body => {
-    const error = body?.errors?.[0];
+export const getErrorMessage = (errors) => {
+  const error = errors?.[0];
 
-    if (!error) {
-      return;
-    }
+  const emptyErrors = {
+    fieldErrors: [],
+    commonErrors: [],
+  };
 
-    if (error.code === NOTE_TYPES_LIMIT_REACHED_ERROR) {
-      const limit = error.parameters.find(param => param.key === 'limit');
-      sendCallout({
-        type: 'error',
-        message: <FormattedMessage id="ui-notes.settings.maxAmount" values={{ amount: limit?.value }} />,
-      });
-    }
-  });
+  if (!error) {
+    return emptyErrors;
+  }
+
+  if (error.code === NOTE_TYPES_LIMIT_REACHED_ERROR) {
+    const limit = error.parameters.find(param => param.key === 'limit');
+
+    return {
+      fieldErrors: [],
+      commonErrors: [<FormattedMessage id="ui-notes.settings.maxAmount" values={{ amount: limit?.value }} />],
+    };
+  }
+
+  return emptyErrors;
 };

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import { waitFor } from '@folio/jest-config-stripes/testing-library/react';
-
 import {
   getErrorMessage,
   NOTE_TYPES_LIMIT_REACHED_ERROR,
@@ -52,7 +50,7 @@ describe('Notes utils', () => {
 
         expect(getErrorMessage(errors)).toEqual({
           fieldErrors: [],
-          commonErrors: [expect.objectContaining({ id: 'ui-notes.settings.maxAmount' })],
+          commonErrors: [expect.any(Object)],
         });
       });
     });

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import { waitFor } from '@folio/jest-config-stripes/testing-library/react';
 
 import {
-  handleCreateFail,
+  getErrorMessage,
   NOTE_TYPES_LIMIT_REACHED_ERROR,
   validate,
 } from './util';
@@ -39,9 +39,9 @@ describe('Notes utils', () => {
     });
   });
 
-  describe('handleCreateFail', () => {
+  describe('getErrorMessage', () => {
     describe('when error is due to limit reached', () => {
-      it('should show a callout message', async () => {
+      it('should return a correct error object', async () => {
         const res = {
           json: jest.fn().mockResolvedValue({
             errors: [{
@@ -54,18 +54,15 @@ describe('Notes utils', () => {
           }),
         };
 
-        const sendCallout = jest.fn();
-
-        handleCreateFail(res, sendCallout);
-
-        await waitFor(() => expect(sendCallout).toHaveBeenCalledWith(expect.objectContaining({
-          type: 'error',
-        })));
+        expect(getErrorMessage(res)).toEqual({
+          fieldErrors: [],
+          commonErrors: [expect.objectContaining({ id: 'ui-notes.settings.maxAmount' })],
+        });
       });
     });
 
     describe('when error is due to another reason', () => {
-      it('should not show the callout message', async () => {
+      it('should return empty errors', async () => {
         const res = {
           json: jest.fn().mockResolvedValue({
             errors: [{
@@ -75,11 +72,10 @@ describe('Notes utils', () => {
           }),
         };
 
-        const sendCallout = jest.fn();
-
-        handleCreateFail(res, sendCallout);
-
-        await waitFor(() => expect(sendCallout).not.toHaveBeenCalledWith());
+        expect(getErrorMessage(res)).toEqual({
+          fieldErrors: [],
+          commonErrors: [],
+        });
       });
     });
   });

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -42,19 +42,15 @@ describe('Notes utils', () => {
   describe('getErrorMessage', () => {
     describe('when error is due to limit reached', () => {
       it('should return a correct error object', async () => {
-        const res = {
-          json: jest.fn().mockResolvedValue({
-            errors: [{
-              code: NOTE_TYPES_LIMIT_REACHED_ERROR,
-              parameters: [{
-                key: 'limit',
-                value: 25,
-              }],
-            }],
-          }),
-        };
+        const errors = [{
+          code: NOTE_TYPES_LIMIT_REACHED_ERROR,
+          parameters: [{
+            key: 'limit',
+            value: 25,
+          }],
+        }];
 
-        expect(getErrorMessage(res)).toEqual({
+        expect(getErrorMessage(errors)).toEqual({
           fieldErrors: [],
           commonErrors: [expect.objectContaining({ id: 'ui-notes.settings.maxAmount' })],
         });
@@ -63,16 +59,12 @@ describe('Notes utils', () => {
 
     describe('when error is due to another reason', () => {
       it('should return empty errors', async () => {
-        const res = {
-          json: jest.fn().mockResolvedValue({
-            errors: [{
-              code: 'unknown',
-              parameters: [],
-            }],
-          }),
-        };
+        const errors = [{
+          code: 'unknown',
+          parameters: [],
+        }];
 
-        expect(getErrorMessage(res)).toEqual({
+        expect(getErrorMessage(errors)).toEqual({
           fieldErrors: [],
           commonErrors: [],
         });


### PR DESCRIPTION
## Description
[Previous PR](https://github.com/folio-org/ui-notes/pull/269) involved providing a custom error handler to `<ControlledVocab>`, but it caused list of items to not refresh when an item creation failed.
Instead the new approach is to provide an error message getter via props. This way when an item creation fails - the list is still refreshed.

## Screenshots

https://github.com/user-attachments/assets/11ccb941-9b46-4fc9-a567-8a4abfb2863e



## Issues
[UINOTES-173](https://folio-org.atlassian.net/browse/UINOTES-173)