### PR TITLE
UINOTES-173 update translation for note types limit error message (follow-up)

### DIFF
--- a/translations/ui-notes/en.json
+++ b/translations/ui-notes/en.json
@@ -9,7 +9,7 @@
   "settings.noteTypes.termWillBeDeleted": "The note type <b>{term}</b> will be <b>deleted.</b>",
   "settings.notes": "Notes",
   "settings.duplicated": "{field} duplicated",
-  "settings.maxAmount": "Maximum # of note types allowed is {amount}.",
+  "settings.maxAmount": "Maximum number of note types allowed is {amount}.",
   "settings.label": "Notes settings",
 
   "permission.module.notes.enabled": "UI: ui-notes module is enabled",


### PR DESCRIPTION
## Description
update translation for note types limit error message to say `Maximum number of note types allowed is {amount}.`

## Issues
[UINOTES-173](https://folio-org.atlassian.net/browse/UINOTES-173)