### PR TITLE
UINOTES-179 include universal read-only permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Settings > Notes> Add Notes application icon. (UINOTES-169)
 * *BREAKING* Handle BE error when a note type limit has been reached. (UINOTES-173)
+* Include universal read-only permissions. (UINOTES-179)
 
 ## [11.0.0] (https://github.com/folio-org/ui-notes/tree/v11.0.0) (2025-03-13)
 [Full Changelog](https://github.com/folio-org/ui-notes/compare/v10.0.0...v11.0.0)

--- a/package.json
+++ b/package.json
@@ -68,13 +68,17 @@
       {
         "permissionName": "module.notes.enabled",
         "displayName": "UI: ui-notes module is enabled",
-        "visible": false
+        "visible": false,
+        "subPermissions": [
+          "stripes-core.settings.read"
+        ]
       },
       {
         "permissionName": "settings.notes.enabled",
         "visible": false,
         "subPermissions": [
-          "settings.enabled"
+          "settings.enabled",
+          "stripes-core.settings.read"
         ]
       },
       {


### PR DESCRIPTION
Use stripes-core's univeral read-only permission set so users who _only_ have access to this app have the necessary permissions to execute API queries during session init.

Refs [UINOTES-179](https://folio-org.atlassian.net/browse/UINOTES-179), [STRIPES-997](https://folio-org.atlassian.net/browse/STRIPES-997)